### PR TITLE
Test coverage scripts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ sphinx
 tweepy
 python-dotenv
 django-environ
+django-nose
+coverage

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ python-dotenv
 django-environ
 django-nose
 coverage
+testfixtures

--- a/scripts/django_tests.sh
+++ b/scripts/django_tests.sh
@@ -1,0 +1,3 @@
+cd ..
+cd wingspan
+python3 manage.py test --with-coverage

--- a/scripts/django_tests.sh
+++ b/scripts/django_tests.sh
@@ -1,3 +1,4 @@
 cd ..
 cd wingspan
-python3 manage.py test --with-coverage
+# python3 manage.py test --with-coverage -m
+coverage run --source='.' manage.py test 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,1 +1,2 @@
+cd ../wingspan
 npm start & python3 manage.py runserver && kill $!

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
-. $(brew --prefix nvm)/nvm.sh
+. ~/.nvm/nvm.sh
+. ~/.profile
+. ~/.bashrc
+. $(brew --prefix nvm)/nvm.sh  # if installed via Brew
 nvm install 17.1.0
 nvm use 17.1.0
+cd wingspan
+npm install 
 pip install -r ../requirements.txt

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,10 +1,4 @@
 #!/bin/bash
-. ~/.nvm/nvm.sh
-. ~/.profile
-. ~/.bashrc
-. $(brew --prefix nvm)/nvm.sh  # if installed via Brew
-nvm install 17.1.0
-nvm use 17.1.0
-cd wingspan
+cd ../wingspan
 npm install 
 pip install -r ../requirements.txt

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+. $(brew --prefix nvm)/nvm.sh
+nvm install 17.1.0
+nvm use 17.1.0
+pip install -r ../requirements.txt

--- a/wingspan/.coveragerc
+++ b/wingspan/.coveragerc
@@ -1,2 +1,5 @@
+[run]
+branch=True
+
 [report]
 show_missing=True

--- a/wingspan/.coveragerc
+++ b/wingspan/.coveragerc
@@ -1,0 +1,2 @@
+[report]
+show_missing=True

--- a/wingspan/tanalysis/test_sentiment.py
+++ b/wingspan/tanalysis/test_sentiment.py
@@ -26,3 +26,13 @@ class SentimentTestCase(TestCase):
         for score in score_data:
             self.assertTrue(score["score"] is not None)
             self.assertTrue(score["timestamp"] is not None)
+
+    def test_analyze_tweets2(self):
+        # os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = 'username'
+        del os.environ['GOOGLE_APPLICATION_CREDENTIALS']
+        sa = SentimentAnalyzer()
+        score_data = sa.analyzeTweets([self.tweet])
+        
+        for score in score_data:
+            self.assertTrue(score["score"] is not None)
+            self.assertTrue(score["timestamp"] is not None)

--- a/wingspan/tanalysis/test_sentiment.py
+++ b/wingspan/tanalysis/test_sentiment.py
@@ -27,8 +27,7 @@ class SentimentTestCase(TestCase):
             self.assertTrue(score["score"] is not None)
             self.assertTrue(score["timestamp"] is not None)
 
-    def test_analyze_tweets2(self):
-        # os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = 'username'
+    def test_analyze_tweets_without_credentials(self):
         del os.environ['GOOGLE_APPLICATION_CREDENTIALS']
         sa = SentimentAnalyzer()
         score_data = sa.analyzeTweets([self.tweet])

--- a/wingspan/tanalysis/test_twittercom.py
+++ b/wingspan/tanalysis/test_twittercom.py
@@ -1,4 +1,3 @@
-from django.db.models.query_utils import Q
 from django.test import TestCase
 #from django.utils import timezone
 import os
@@ -67,4 +66,3 @@ class TwitterComTestCase(TestCase):
         self.assertTrue(len(top_tweets) <= len(tweets))
         self.assertTrue(verified_count == len(top_tweets))
         self.assertTrue(len(top_tweets) == len(set(tids)))
-

--- a/wingspan/tanalysis/test_twittercom.py
+++ b/wingspan/tanalysis/test_twittercom.py
@@ -1,3 +1,4 @@
+from django.db.models.query_utils import Q
 from django.test import TestCase
 #from django.utils import timezone
 import os
@@ -66,4 +67,4 @@ class TwitterComTestCase(TestCase):
         self.assertTrue(len(top_tweets) <= len(tweets))
         self.assertTrue(verified_count == len(top_tweets))
         self.assertTrue(len(top_tweets) == len(set(tids)))
- 
+

--- a/wingspan/tanalysis/test_twittercom.py
+++ b/wingspan/tanalysis/test_twittercom.py
@@ -1,10 +1,11 @@
 from django.test import TestCase
 #from django.utils import timezone
-#import os
+import os
 import unittest
 
 from .models import Query, User
 from .twittercom import TwitterCom
+
 
 class TwitterComTestCase(TestCase):
     def setUp(self):
@@ -65,4 +66,4 @@ class TwitterComTestCase(TestCase):
         self.assertTrue(len(top_tweets) <= len(tweets))
         self.assertTrue(verified_count == len(top_tweets))
         self.assertTrue(len(top_tweets) == len(set(tids)))
-
+ 

--- a/wingspan/tanalysis/test_twittercom_bad_auth.py
+++ b/wingspan/tanalysis/test_twittercom_bad_auth.py
@@ -1,0 +1,23 @@
+from django.test import TestCase
+import os
+
+from unittest.mock import patch # For python 2.x use from mock import patch
+from .twittercom import TwitterCom
+from testfixtures import LogCapture
+
+class TwitterComBadAuth(TestCase):
+    def setUp(self):
+        del os.environ['API_KEY']
+        del os.environ['API_SECRET']
+        del os.environ['ACCESS_TOKEN']
+        del os.environ['SECRET_ACCESS_TOKEN']
+
+    @patch('tanalysis.test_twittercom_bad_auth')
+    def test_logging_error(self, mock_logger):
+
+        with LogCapture() as l:
+            self.tcom = TwitterCom()
+        l.check(
+            ('root', 'ERROR', 'Authentication Error.'),
+        )
+       

--- a/wingspan/wingspan/settings.py
+++ b/wingspan/wingspan/settings.py
@@ -42,6 +42,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django_nose',
 ]
 
 MIDDLEWARE = [
@@ -55,6 +56,15 @@ MIDDLEWARE = [
 ]
 
 ROOT_URLCONF = 'wingspan.urls'
+
+# Use nose to run all tests
+TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
+
+# Tell nose to measure coverage on the 'foo' and 'bar' apps
+NOSE_ARGS = [
+    '--with-coverage',
+    '--cover-package=tanalysis',
+]
 
 TEMPLATES = [
     {


### PR DESCRIPTION
- installing dependencies, running the app, and running tests are handled accordingly scripts in /scripts.
- don't forget to add the google auth json file from Alex into the proj. once you do that, update your .env with
"GOOGLE_APPLICATION_CREDENTIALS=path/to/json/file"
- also, make sure to run /scripts/setup.sh because of some new django dependencies.
- for the backend tests, statement and branch coverage is at 100% for sentiment module, but at 88% for twittercom. One the misses is from catching an error from tweepy, which I wasnt actually sure how go down that path. these percentages may change during the merge with erica's update to TwitterCom.py